### PR TITLE
feat: add dynamic payload support in schema controller

### DIFF
--- a/src/controller/schema_controller.ts
+++ b/src/controller/schema_controller.ts
@@ -2,8 +2,10 @@ import * as Cord from '@cord.network/sdk';
 import express from 'express';
 import { getConnection } from 'typeorm';
 import 'reflect-metadata';
-
+import { validateSchema } from '../utils/SchemaValidationUtils';
+import { extractSchemaFields } from '../utils/SchemaUtils';
 import { Schema } from '../entity/Schema';
+
 import {
   addDelegateAsRegistryDelegate,
   authorIdentity,
@@ -22,18 +24,20 @@ export async function createSchema(
       await addDelegateAsRegistryDelegate();
     }
 
-    const data = req.body.schema;
+    let data = req.body.schema?.schema || req.body.schema || null;
 
-    if (!data || !data.properties) {
-      return res.status(400).json({
-        error:
-          "'schema' is a required field in the form of key-value pair, with title and description",
-      });
-    }
-
+    
+    const validationError = validateSchema(data);
+    if (validationError) {
+      return res.status(400).json({ error: validationError });
+        }
+    
+    data = extractSchemaFields(data)
+   
+   
     let newSchemaName = data.title + ':' + Cord.Utils.UUID.generate();
     data.title = newSchemaName;
-    data.type = 'object';
+    
 
     let schemaDetails = await Cord.Schema.buildFromProperties(
       data,

--- a/src/types/Schema.interface.ts
+++ b/src/types/Schema.interface.ts
@@ -1,0 +1,38 @@
+export type PropertyType =
+  | StringProperty
+  | NumberProperty
+  | BooleanProperty
+  | ArrayProperty
+  | ObjectProperty;
+
+export interface StringProperty {
+  type: 'string';
+  enum?: string[];
+  format?: 'date' | 'time' | 'uri';
+  minLength?: number;
+  maxLength?: number;
+}
+
+export interface NumberProperty {
+  type: 'integer' | 'number';
+  enum?: number[];
+  minimum?: number;
+  maximum?: number;
+}
+
+export interface BooleanProperty {
+  type: 'boolean';
+}
+
+export interface ArrayProperty {
+  type: 'array';
+  items: PropertyType;
+  minItems?: number;
+  maxItems?: number;
+}
+
+export interface ObjectProperty {
+  type: 'object';
+  properties: Record<string, PropertyType>;
+  required?: string[];
+}

--- a/src/utils/SchemaUtils.ts
+++ b/src/utils/SchemaUtils.ts
@@ -1,0 +1,72 @@
+import { PropertyType ,ObjectProperty} from "../types/Schema.interface";
+ 
+
+export function extractSchemaFields(schema: any) {
+  if (!schema || typeof schema !== 'object') {
+    throw new Error("Invalid schema: Schema must be a valid object.");
+  }
+
+  
+  const extractProperty = (property: any): PropertyType => {
+    switch (property.type) {
+      case 'string': {
+        const { type, enum: enumValues, format, minLength, maxLength } = property;
+        return {
+          type,
+          ...(enumValues && { enum: enumValues }),
+          ...(format && { format }),
+          ...(minLength && { minLength }),
+          ...(maxLength && { maxLength })
+        };
+      }
+      case 'integer':
+      case 'number': {
+        const { type, enum: enumValues, minimum, maximum } = property;
+        return {
+          type,
+          ...(enumValues && { enum: enumValues }),
+          ...(minimum && { minimum }),
+          ...(maximum && { maximum })
+        };
+      }
+      case 'array': {
+        const { type, items, minItems, maxItems } = property;
+        return {
+          type,
+          items: extractProperty(items), 
+          ...(minItems && { minItems }),
+          ...(maxItems && { maxItems })
+        };
+      }
+      case 'object': {
+        const { type, properties, required } = property;
+        return {
+          type,
+          properties: Object.keys(properties).reduce((acc, key) => {
+            acc[key] = extractProperty(properties[key]);
+            return acc;
+          }, {} as ObjectProperty['properties']), 
+          ...(required && { required })
+        };
+      }
+      case 'boolean':
+        return { type: 'boolean' };
+      default:
+        throw new Error(`Unsupported property type: ${property.type}`);
+    }
+  };
+
+
+  const properties = Object.keys(schema.properties || {}).reduce((acc, key) => {
+    acc[key] = extractProperty(schema.properties[key]);
+    return acc;
+  }, {} as Record<string, PropertyType>);
+
+
+  return {
+    title: schema.title || schema.$id, 
+    properties,
+    required: schema.required || [], 
+    type: 'object',
+  };
+}

--- a/src/utils/SchemaValidationUtils.ts
+++ b/src/utils/SchemaValidationUtils.ts
@@ -1,0 +1,11 @@
+
+export function validateSchema(data:any) {
+    
+    if (!data) return "'schema' is required.";
+    if (!data.title && !data.$id) return "'title' or '$id' is required.";
+    if (!data.description) return "'description' is required.";
+    if (!data.properties) return "'properties' is required.";
+    if (Object.keys(data.properties).length === 0) return "'properties' must contain at least one property.";
+    return null;
+  }
+  


### PR DESCRIPTION
This pull request adds the ability for the schema controller in the Issuer Agent to handle dynamic payloads. This means the API can now work with different types of data sent in requests. Currently, the API only accepts the expected request payload and directly passes it to SDK functions, which can throw errors if the payload format doesn't match.

In this PR, validation has been added to extract only the necessary fields before passing them to the function. Now, the API can accept different JSON formats while still extracting the required fields. Additionally, an interface for properties has been created to align with the Cord SDK